### PR TITLE
Upgrade project to Azure Functions v2 RTM

### DIFF
--- a/AllReady.Processing/AllReady.Processing/AllReady.Processing.csproj
+++ b/AllReady.Processing/AllReady.Processing/AllReady.Processing.csproj
@@ -1,9 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.23" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/AllReady.Processing/AllReady.Processing/QueueTest.cs
+++ b/AllReady.Processing/AllReady.Processing/QueueTest.cs
@@ -1,6 +1,6 @@
 using System;
 using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
 
 namespace AllReady.Processing
 {
@@ -10,9 +10,9 @@ namespace AllReady.Processing
         // local storage emulator.
 
         [FunctionName("QueueTest")]
-        public static void Run([QueueTrigger("queue-test", Connection = "")]string item, TraceWriter log)
+        public static void Run([QueueTrigger("queue-test")]string item, ILogger log)
         {            
-            log.Info($"A message was dequeued from the queue-test queue: {item}");
+            log.LogInformation($"A message was dequeued from the queue-test queue: {item}");
         }
     }
 }


### PR DESCRIPTION
As part of the upgrade, a developer's local machine should include a file called `local.settings.json` the project root with the following content:
````
{
  "IsEncrypted": false,
  "Values": {
    "FUNCTIONS_EXTENSION_VERSION ": "~2",
    "FUNCTIONS_WORKER_RUNTIME":  "dotnet", 
    "AzureWebJobsStorage": "UseDevelopmentStorage=true"
  }
}
````